### PR TITLE
Recompose dependency removed for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "react": "~16.5.2",
-    "react-dom": "~16.5.2",
-    "react-scripts": "1.1.5",
     "@material-ui/core": "3.1.1",
     "@material-ui/icons": "3.0.1",
     "bootstrap": "4.1.1",
@@ -13,19 +10,21 @@
     "html-encoder-decoder": "1.3.7",
     "jquery": "3.3.1",
     "moment": "2.22.2",
+    "react": "~16.5.2",
     "react-block-ui": "1.1.2",
     "react-custom-scrollbars": "4.2.1",
     "react-datepicker": "1.5.0",
+    "react-dom": "~16.5.2",
     "react-google-button": "0.5.3",
     "react-google-login": "3.2.1",
     "react-icons": "2.2.7",
     "react-router": "4.2.0",
     "react-router-dom": "4.2.2",
+    "react-scripts": "1.1.5",
     "react-spinners": "0.3.2",
     "react-vertical-timeline-component": "2.1.3",
     "react-youtube": "7.6.0",
-    "reactstrap": "6.0.1",
-    "recompose": "0.28.2"
+    "reactstrap": "6.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
ModuleNotFoundError
Could not find module in path: '@babel/runtime/7.0.0-beta.56/helpers/interopRequireDefault' relative to '/node_modules/recompose/wrapDisplayName.js'

This error is produced when I run the project on codesandbox